### PR TITLE
Publish dnsqry through the Homebrew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ Or directly install any one of the formula (without tapping):
 ```
 brew install wiztools/repo/<formula>
 ```
+
+Available formulae:
+
+- `cidrinfo`
+- `dnsqry`
+- `knowledged`

--- a/dnsqry.rb
+++ b/dnsqry.rb
@@ -1,0 +1,18 @@
+class Dnsqry < Formula
+  desc "Fast and simple DNS query tool"
+  homepage "https://github.com/wiztools/dnsqry"
+  url "https://github.com/wiztools/dnsqry/archive/refs/tags/v0.2.0.tar.gz"
+  sha256 "22d585697abd3096d9afe9022264c3b8f9214e0fccff1bcf3b1d452b8b4e7af2"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match "DNS query tool", shell_output("#{bin}/dnsqry --help")
+    assert_match "google", shell_output("#{bin}/dnsqry --help")
+  end
+end


### PR DESCRIPTION
## Summary
- add a Homebrew formula for dnsqry pinned to the current published source revision
- document dnsqry in the tap README formula list

## Verification
- ruby -c dnsqry.rb

## Notes
- brew audit/install could not be fully run locally because this checkout is not Homebrew's registered tap checkout; Homebrew rejected raw-path formula checks in this environment.