### PR TITLE
Trigger initial bottle builds for tap formulae

### DIFF
--- a/cidrinfo.rb
+++ b/cidrinfo.rb
@@ -3,7 +3,7 @@ class Cidrinfo < Formula
   homepage "https://github.com/wiztools/cidrinfo"
   url "https://github.com/wiztools/cidrinfo/archive/refs/tags/0.1.1.tar.gz"
   sha256 "3c4c99003188edb219619a6878f260de959690ffc93e5aa3f9d41c69fa76c9c5"
-  revision 1
+  revision 2
 
   depends_on "go" => :build
 

--- a/dnsqry.rb
+++ b/dnsqry.rb
@@ -4,6 +4,7 @@ class Dnsqry < Formula
   url "https://github.com/wiztools/dnsqry/archive/refs/tags/v0.2.0.tar.gz"
   sha256 "22d585697abd3096d9afe9022264c3b8f9214e0fccff1bcf3b1d452b8b4e7af2"
   license "MIT"
+  revision 1
 
   depends_on "rust" => :build
 

--- a/knowledged.rb
+++ b/knowledged.rb
@@ -4,6 +4,7 @@ class Knowledged < Formula
   url "https://github.com/wiztools/knowledged/archive/refs/tags/v0.1.0.tar.gz"
   sha256 "b80983bfe136fe021f6d56bce6b268f64406d7feb50ed8bc7315d3afcc86fecd"
   license "MIT"
+  revision 1
 
   depends_on "go" => :build
 


### PR DESCRIPTION
## Summary
- bump formula revisions for cidrinfo, dnsqry, and knowledged
- trigger Homebrew test-bot bottle artifacts for the active tap formulae
- leave bottle checksums to the existing pr-pull workflow after CI passes

## Follow-up
After CI passes, add the `pr-pull` label so `.github/workflows/publish.yml` can publish bottles and append the generated `bottle do` blocks.

## Verification
- `brew test-bot --only-tap-syntax`
- `brew audit --strict --online cidrinfo dnsqry knowledged`