### PR TITLE
Publish knowledged 0.1.1 bottles

### DIFF
--- a/knowledged.rb
+++ b/knowledged.rb
@@ -5,6 +5,12 @@ class Knowledged < Formula
   sha256 "b4cf4430e018989f44e889c69850130ab80f595fbe0a5ce6f87f4d0751b9b807"
   license "MIT"
 
+  bottle do
+    root_url "https://github.com/wiztools/homebrew-repo/releases/download/knowledged-0.1.1"
+    sha256 cellar: :any_skip_relocation, arm64_tahoe:  "4695ca0bbec1f989e874c61b5d21c9bba9f5349c38573671608c204762fbdd7e"
+    sha256 cellar: :any,                 x86_64_linux: "481acb9bd6ba3f9b49ed4f10137fb03af26ab0794538377161aa4dbc39e88ea3"
+  end
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
## Summary
- Add the bottle block generated from the successful knowledged 0.1.1 PR artifacts
- Published the matching bottle tarballs to the expected GitHub release

## Context
The post-merge pr-pull label trigger did start, but failed because the original formula PR had already been merged, making the cherry-pick empty. This PR records the bottle metadata separately.

## Verification
- ruby -c knowledged.rb
- brew audit --strict knowledged
- brew fetch --formula --force-bottle knowledged